### PR TITLE
Migrate from master/slave words

### DIFF
--- a/kviz/migrations/0002_slave_email.py
+++ b/kviz/migrations/0002_slave_email.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name='slave',
+            model_name='subordinate',
             name='email',
             field=models.EmailField(blank=True, max_length=70),
         ),

--- a/kviz/views.py
+++ b/kviz/views.py
@@ -14,15 +14,15 @@ class QuestionList(APIView):
         return HttpResponse(data, content_type='application/json')
 
 
-class SlaveScore(APIView):
+class SubordinateScore(APIView):
     def post(self, request):
-        slave = {
+        subordinate = {
             'name': request.data['name'],
             'surname': request.data['surname'],
             'score': request.data['score'],
             'email': request.data['email'],
         }
-        serializer = SlaveSerializer(data=slave)
+        serializer = SubordinateSerializer(data=subordinate)
         if serializer.is_valid():
             serializer.save()
             return HttpResponse(status=200)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.